### PR TITLE
Fix after-all function to append blockers as list

### DIFF
--- a/src/test/tree/builder.clj
+++ b/src/test/tree/builder.clj
@@ -173,7 +173,7 @@
   [t n]
   (-> n
      tz/test-zip
-     (zip/append-child (assoc t :blockers (wait-for-tree n)))
+     (zip/append-child (update t :blockers conj (wait-for-tree n)))
      zip/root))
 
 (defn read-tests [f] "Read a file that contains tests"


### PR DESCRIPTION
:blockers needs to be a list, and when using `after-all`, it wasn't.